### PR TITLE
Fix rails 7.2

### DIFF
--- a/app/models/pay/charge.rb
+++ b/app/models/pay/charge.rb
@@ -2,9 +2,6 @@ module Pay
   class Charge < ApplicationRecord
     self.table_name = Pay.chargeable_table
 
-    # Only serialize for non-json columns
-    serialize :data, coder: JSON unless json_column?("data")
-
     # Associations
     belongs_to :owner, polymorphic: true
 

--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -4,9 +4,6 @@ module Pay
 
     STATUSES = %w[incomplete incomplete_expired trialing active past_due canceled unpaid paused]
 
-    # Only serialize for non-json columns
-    serialize :data, coder: JSON unless json_column?("data")
-
     # Associations
     belongs_to :owner, polymorphic: true
 

--- a/lib/pay/env.rb
+++ b/lib/pay/env.rb
@@ -14,17 +14,12 @@ module Pay
     def find_value_by_name(scope, name)
       ENV["#{scope.upcase}_#{name.upcase}"] ||
         credentials&.dig(env, scope, name) ||
-        secrets&.dig(env, scope, name) ||
         credentials&.dig(scope, name) ||
         secrets&.dig(scope, name)
     end
 
     def env
       Rails.env.to_sym
-    end
-
-    def secrets
-      Rails.application.secrets
     end
 
     def credentials


### PR DESCRIPTION
Hey team,

To be compatible with Rails 7.2 we need to:
- Remove secrets because they are removed from Rails 7.2
- JSON columns does not need serialize method. There was an error related with that. It is safe to remove this sentence. Also if I remember correctly I discuss this with @augustopetraglia and this columns are not being used.

I made a new PR on Circle pointing to this branch so we can run the entire Circle CI against this change. Everything passes here: https://github.com/circleco/circle/pull/26585